### PR TITLE
Update submodules to point at the puppetlabs modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "modules/apt"]
 	path = modules/apt
-	url = git://github.com/puppetlabs/puppet-apt.git
+	url = git://github.com/puppetlabs/puppetlabs-apt.git
 [submodule "modules/mysql"]
 	path = modules/mysql
 	url = git://github.com/bodepd/puppetlabs-mysql.git
@@ -21,7 +21,7 @@
 	url = git://github.com/puppetlabs/puppetlabs-create_resources.git
 [submodule "modules/concat"]
 	path = modules/concat
-	url = git://github.com/puppetlabs/puppet-concat
+	url = git://github.com/puppetlabs/puppetlabs-concat
 [submodule "modules/keystone"]
 	path = modules/keystone
 	url = git://github.com/puppetlabs/puppetlabs-keystone
@@ -45,7 +45,7 @@
 	url = git://github.com/puppetlabs/puppetlabs-keystone
 [submodule "modules/vcsrepo"]
 	path = modules/vcsrepo
-	url = git://github.com/puppetlabs/puppet-vcsrepo
+	url = git://github.com/puppetlabs/puppetlabs-vcsrepo
 [submodule "modules/horizon"]
 	path = modules/horizon
 	url = https://github.com/puppetlabs/puppetlabs-horizon.git


### PR DESCRIPTION
Straight-forward fix for repointing:

puppet-apt -> puppetlabs-apt
puppet-concat -> puppetlabs-concat
puppet-vcsrepo -> puppetlabs-vcsrepo